### PR TITLE
remove link from headline in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TestResultWebApp ([TRWebApp](https://github.com/test-fullautomation/testresultwebapp))
+# TestResultWebApp (TRWebApp)
 
 ## Table of Contents
 
@@ -6,7 +6,7 @@
 -   [Usage](#usage)
 -   [Import data](#import-data)
 -   [Contribution](#contribution)
--   [Sourcecode Documentation](#documentation)
+-   [Documentation](#documentation)
 -   [Feedback](#feedback)
 -   [About](#about)
     -   [Maintainers](#maintainers)

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-TestResultWebApp (TRWebApp_)
-============================
+TestResultWebApp (TRWebApp)
+===========================
 
 Table of Contents
 -----------------
@@ -8,7 +8,7 @@ Table of Contents
 -  `Usage <#usage>`__
 -  `Import data <#import-data>`__
 -  `Contribution <#contribution>`__
--  `Sourcecode Documentation <#documentation>`__
+-  `Documentation <#documentation>`__
 -  `Feedback <#feedback>`__
 -  `About <#about>`__
 


### PR DESCRIPTION
Hi Thomas,
Hi Holger,

The link is removed from the headline to avoid warning now.

Thank you,
Ngoan


